### PR TITLE
keyerror: added ['results'] to resolve

### DIFF
--- a/src/sky/sky.py
+++ b/src/sky/sky.py
@@ -499,7 +499,7 @@ class Sky:
         raw_list = self.get(endpoint=f"lists/advanced/{list_id}", raw_data=True)
         # Type casting the data to a dataframe
 
-        data = pd.json_normalize(raw_list["rows"], "columns").reset_index()
+        data = pd.json_normalize(raw_list["results"]["rows"], "columns").reset_index()
         return cleanAdvancedList(data)
 
     def _loadCachedToken(self) -> Union[None, OAuth2Token]:


### PR DESCRIPTION
Added the ["results"] key to resolve the keyerror.

Worked in testing to pull a few advanced lists.