### PR TITLE
Fixed advanced list over 1000 rows logic

### DIFF
--- a/src/sky/sky.py
+++ b/src/sky/sky.py
@@ -507,8 +507,8 @@ class Sky:
         main = []
 
         # Run through ~20 pages, which will equate to 20,000 rows max
+        temp = []
         for i in range(1, 21):
-            temp = []
             val = self.get(endpoint=f"lists/advanced/{list_id}?page={i}", raw_data=True)
             temp.append(val)
 

--- a/src/sky/sky.py
+++ b/src/sky/sky.py
@@ -505,16 +505,12 @@ class Sky:
 
         # A list to hold all dataframes for queries longer than 1000 rows
         main = []
-
-        # Run through ~20 pages, which will equate to 20,000 rows max
-        temp = []
-        for i in range(1, 21):
+        
+        # Run through ~100 pages, which will equate to 100,000 rows max
+        for i in range(1, 101):
             val = self.get(endpoint=f"lists/advanced/{list_id}?page={i}", raw_data=True)
-            temp.append(val)
 
-            # If a match is found, break. This will prevent duplicate
-            # data for queries < 1000 rows.
-            if i > 1 and val == temp[i - 2]:
+            if val['count'] == 0:
                 break
             else:
                 main.append(


### PR DESCRIPTION
previous commit attempt failed because it was resetting the temp variable on every loop. Now we reference the count value returned and break if it's 0, which I believe works better. 